### PR TITLE
Zot/named tuples

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -110,7 +110,6 @@ Struct() = UnorderedStruct()
 
 StructType(u::Union) = Struct()
 StructType(::Type{Any}) = Struct()
-StructType(::Type{<:NamedTuple}) = Struct()
 
 """
     StructTypes.StructType(::Type{T}) = StructTypes.Mutable()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -569,6 +569,8 @@ StructTypes.StructType(::Type{C2}) = StructTypes.Mutable()
                                         @NamedTuple{b::Union{Int, Nothing}}((nothing,))),
             (@NamedTuple{b::Union{Int, Nothing}, c::Int},   (;a = 1, c = 3),
                                         @NamedTuple{b::Union{Int, Nothing}, c::Int}((nothing, 3))),
+            (@NamedTuple{b::Union{Int, Nothing}, c::Int},   (;a = 1, b=2, c = 3),
+                                        @NamedTuple{b::Union{Int, Nothing}, c::Int}((2, 3))),
         ]
         for (given_type, given_data, expected_data) in cases
             data = StructTypes.constructfrom(given_type, given_data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -569,7 +569,7 @@ StructTypes.StructType(::Type{C2}) = StructTypes.Mutable()
                                         @NamedTuple{b::Union{Int, Nothing}}((nothing,))),
             (@NamedTuple{b::Union{Int, Nothing}, c::Int},   (;a = 1, c = 3),
                                         @NamedTuple{b::Union{Int, Nothing}, c::Int}((nothing, 3))),
-            (@NamedTuple{b::Union{Int, Nothing}, c::Int},   (;a = 1, b=2, c = 3),
+            (@NamedTuple{b::Union{Int, Nothing}, c::Int},   (;a = 1, b = 2, c = 3),
                                         @NamedTuple{b::Union{Int, Nothing}, c::Int}((2, 3))),
         ]
         for (given_type, given_data, expected_data) in cases

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -561,6 +561,21 @@ StructTypes.StructType(::Type{C2}) = StructTypes.Mutable()
             @test StructTypes.constructfrom(NamedTuple{(:a, :b, :c), Tuple{Int64, Float64, String}}, x) == (a=1, b=2.0, c="three")
         end
     end
+    @testset "named tuples" begin
+        cases = [
+            (NamedTuple,                                    (;a=1), (;a=1)),
+            (@NamedTuple{a::Int},                           (;a=1), (;a=1)),
+            (@NamedTuple{b::Union{Int, Nothing}},           (;a=1),
+                                        @NamedTuple{b::Union{Int, Nothing}}((nothing,))),
+            (@NamedTuple{b::Union{Int, Nothing}, c::Int},   (;a = 1, c = 3),
+                                        @NamedTuple{b::Union{Int, Nothing}, c::Int}((nothing, 3))),
+        ]
+        for (given_type, given_data, expected_data) in cases
+            data = StructTypes.constructfrom(given_type, given_data)
+            @test typeof(data) == typeof(expected_data)
+            @test data == expected_data
+        end
+    end
 end
 
 struct MyStruct1


### PR DESCRIPTION
Adding named tuple support. This is just to merge this branch into our local copy of the repo. The exact same commits are in this PR for the public repo: https://github.com/JuliaData/StructTypes.jl/pull/75

When this is merged, the branch should remain because it is in the teamsrvr manifest: https://github.com/JuliaComputing/JuliaTeam/blob/master/teamsrvr/Manifest.toml#L784